### PR TITLE
Skip contributors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ ifndef GO111MODULE
 endif
 
 VERSION ?= "master"
+BRANCH ?= "master"
 
 .PHONY: build
 
@@ -55,7 +56,7 @@ release:
 	VERSION=$(VERSION) rpmbuild --undefine=_disable_source_fetch -bb build/rpm/centos7.spec
 
 github-release:
-	scripts/gh-release.sh $(VERSION) false
+	scripts/gh-release.sh $(VERSION) $(BRANCH) false
 
 clean:
 	@rm -rf $(GOPATH)/bin/pacs_* $(GOPATH)/bin/prj_* $(GOPATH)/bin/lab_* $(GOPATH)/bin/pdb*

--- a/scripts/gh-release.sh
+++ b/scripts/gh-release.sh
@@ -28,27 +28,29 @@ function get_script_dir() {
 }
 
 function new_release_post_data() {
-    t=1
-    p=2
+    t=$1
+    b=$2
+    p=$3
     cat <<EOF
 {
-    "tag_name": "${tag}",
-    "tag_commitish": "master",
-    "name": "${tag}",
-    "body": "Release ${tag}",
+    "tag_name": "${t}",
+    "target_commitish": "${b}",
+    "name": "${t}",
+    "body": "Release ${t}",
     "draft": false,
-    "prerelease": $2
+    "prerelease": ${p}
 }
 EOF
 }
 
-if [ $# -ne 2 ]; then
-    echo "$0 <release_number> <is_prerelease>"
+if [ $# -ne 3 ]; then
+    echo "$0 <release_number> <branch> <is_prerelease>"
     exit 1
 fi
 
 rnum=$1
-pre=$2
+branch=$2
+pre=$3
 gh_token=""
 
 # follow the good naming convention for github tag
@@ -89,7 +91,7 @@ done
 # create a new tag with current master branch
 # if the $id of the release is not available.
 if [ ! "$id" ]; then
-    response=$(curl -H "Authorization: token $gh_token" -X POST --data "$(new_release_post_data ${tag} ${pre})" $GH_RELE)
+    response=$(curl -H "Authorization: token $gh_token" -X POST --data "$(new_release_post_data ${tag} ${branch} ${pre})" $GH_RELE)
     eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
     [ "$id" ] || { echo "release tag not created successfully: ${tag}"; exit 1; }
 fi


### PR DESCRIPTION
@RenedBruin I think this change is relevant to you.  Therefore, I assigned you as the reviewer.  Could you please review it and approve the changes if you agree?  Thanks!

The idea is to have an extra option of `pdbutil project alert` command called `--skip-contributor`, and its value can be a comma-separated list of project numbers.  With it, the alert program will skip sending out email to the contributors of those specified projects concerning running out of quota and project expiry.

I can also take 10-15 minutes on next Monday to walk through the changes with you in this PR.