### PR TITLE
make lab_bookings static binary for CentOS6 MEG console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ build_project:
 build:
 	GOPATH=$(GOPATH) GOOS=$(GOOS) GO111MODULE=$(GO111MODULE) go install github.com/dccn-tg/tg-toolset-golang/...
 
+static-binaries:
+	GOPATH=$(GOPATH) GOOS=$(GOOS) CGO_ENABLED=0 GO111MODULE=$(GO111MODULE) go build -o lab_bookings dataflow/cmd/lab_bookings/main.go
+
 test_mailer:
 	@GOPATH=$(GOPATH) GOOS=$(GOOS) GO111MODULE=$(GO111MODULE) go test -v github.com/dccn-tg/tg-toolset-golang/pkg/mailer/...
 


### PR DESCRIPTION
Hi @Stef-Gijsberts this is for now a workaround to build the `lab-bookings` binary without dynamic link.  This is because the binary needs to be transferred to and used by a very old CentOS6 MEG console.

It is not worth to implement something fancy as DCCN is going to phase out the old MEG console in 1-2 years.